### PR TITLE
feat: add SQLite compare support

### DIFF
--- a/consilens-cli/src/main/java/com/consilens/cli/model/ConnectionConfig.java
+++ b/consilens-cli/src/main/java/com/consilens/cli/model/ConnectionConfig.java
@@ -1,5 +1,6 @@
 package com.consilens.cli.model;
 
+import com.consilens.connector.api.enums.DatabaseType;
 import com.consilens.core.validation.ValidationException;
 import com.consilens.core.validation.ValidationFramework;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,6 +20,8 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class ConnectionConfig {
 
+    private static final String SQLITE_JDBC_PREFIX = "jdbc:sqlite:";
+
     @JsonProperty("type")
     private String type;
 
@@ -35,7 +38,69 @@ public class ConnectionConfig {
         ValidationFramework.forContext(fieldName)
                 .notEmpty(url, fieldName + ".url")
                 .validJdbcUrl(url, fieldName + ".url")
+                .throwIfInvalid();
+
+        DatabaseType explicitType = resolveExplicitType(fieldName);
+        boolean sqliteJdbcUrl = isSqliteJdbcUrl(url);
+        DatabaseType detectedType = sqliteJdbcUrl ? DatabaseType.SQLITE : DatabaseType.fromJdbcUrl(url);
+
+        if (explicitType == DatabaseType.SQLITE) {
+            if (!sqliteJdbcUrl) {
+                throw ValidationException.simple("CONFIGURATION_VALIDATION",
+                        fieldName + ".type requires " + fieldName + ".url to start with " + SQLITE_JDBC_PREFIX);
+            }
+            validateSqliteUrl(fieldName);
+            return;
+        }
+
+        if (explicitType != DatabaseType.UNKNOWN) {
+            if (sqliteJdbcUrl) {
+                throw ValidationException.simple("CONFIGURATION_VALIDATION",
+                        fieldName + ".type does not match " + fieldName + ".url: SQLite JDBC URLs require type sqlite or omitted type");
+            }
+            if (detectedType != DatabaseType.UNKNOWN && explicitType != detectedType) {
+                throw ValidationException.simple("CONFIGURATION_VALIDATION",
+                        fieldName + ".type does not match " + fieldName + ".url");
+            }
+        }
+
+        if (sqliteJdbcUrl) {
+            validateSqliteUrl(fieldName);
+            return;
+        }
+
+        ValidationFramework.forContext(fieldName)
                 .notEmpty(username, fieldName + ".username")
                 .throwIfInvalid();
+    }
+
+    private DatabaseType resolveExplicitType(String fieldName) {
+        if (!hasText(type)) {
+            return DatabaseType.UNKNOWN;
+        }
+
+        DatabaseType explicitType = DatabaseType.fromString(type);
+        if (explicitType == DatabaseType.UNKNOWN) {
+            throw ValidationException.simple("CONFIGURATION_VALIDATION",
+                    fieldName + ".type is not a supported database type: " + type);
+        }
+        return explicitType;
+    }
+
+    private void validateSqliteUrl(String fieldName) {
+        String sqliteDataSource = url.substring(SQLITE_JDBC_PREFIX.length());
+        if (!hasText(sqliteDataSource)) {
+            throw ValidationException.simple("CONFIGURATION_VALIDATION",
+                    fieldName + ".url must include a SQLite data source path or :memory:");
+        }
+    }
+
+    private boolean isSqliteJdbcUrl(String jdbcUrl) {
+        return jdbcUrl != null
+                && jdbcUrl.regionMatches(true, 0, SQLITE_JDBC_PREFIX, 0, SQLITE_JDBC_PREFIX.length());
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/consilens-cli/src/test/java/com/consilens/cli/config/ConfigurationManagerTest.java
+++ b/consilens-cli/src/test/java/com/consilens/cli/config/ConfigurationManagerTest.java
@@ -273,4 +273,109 @@ class ConfigurationManagerTest {
 
         assertEquals("Missing required environment variable: SOURCE_URL", exception.getMessage());
     }
+
+    @Test
+    void shouldLoadSqliteConfigurationWithoutUsernameOrPassword() throws Exception {
+        CliConfiguration config = loadConfiguration("sqlite-no-credentials.yaml",
+                sqliteConnectionsYaml("type: sqlite\n  url: jdbc:sqlite:/tmp/source.db\n",
+                        "type: sqlite\n  url: \"jdbc:sqlite::memory:\"\n"));
+
+        assertEquals("sqlite", config.getSource().getType());
+        assertEquals("jdbc:sqlite:/tmp/source.db", config.getSource().getUrl());
+        assertEquals("jdbc:sqlite::memory:", config.getTarget().getUrl());
+    }
+
+    @Test
+    void shouldAllowSqliteAutoDetectionWithoutExplicitType() throws Exception {
+        CliConfiguration config = loadConfiguration("sqlite-auto-detect.yaml",
+                sqliteConnectionsYaml("url: jdbc:sqlite:/tmp/source.db\n",
+                        "url: jdbc:sqlite:/tmp/target.db\n"));
+
+        assertEquals("jdbc:sqlite:/tmp/source.db", config.getSource().getUrl());
+        assertEquals("jdbc:sqlite:/tmp/target.db", config.getTarget().getUrl());
+    }
+
+    @Test
+    void shouldAllowSqliteTypeWithSqlitePrefixedUrlContainingMysqlWord() throws Exception {
+        CliConfiguration config = loadConfiguration("sqlite-explicit-type.yaml",
+                sqliteConnectionsYaml("type: sqlite\n  url: jdbc:sqlite:/tmp/mysql.db\n",
+                        "type: sqlite\n  url: jdbc:sqlite:/tmp/target.db\n"));
+
+        assertEquals("sqlite", config.getSource().getType());
+        assertEquals("jdbc:sqlite:/tmp/mysql.db", config.getSource().getUrl());
+    }
+
+    @Test
+    void shouldFailWhenSqliteTypeUsesNonSqliteJdbcUrl() throws Exception {
+        ConfigurationException exception = assertThrows(ConfigurationException.class,
+                () -> loadConfiguration("sqlite-type-non-sqlite-url.yaml",
+                        sqliteConnectionsYaml("type: sqlite\n  url: jdbc:mysql://localhost:3306/test\n",
+                                "type: sqlite\n  url: jdbc:sqlite:/tmp/target.db\n")));
+
+        assertTrue(exception.getMessage().contains("source.type requires source.url to start with jdbc:sqlite:"));
+    }
+
+    @Test
+    void shouldFailWhenExplicitTypeDoesNotMatchSqliteJdbcUrl() throws Exception {
+        ConfigurationException exception = assertThrows(ConfigurationException.class,
+                () -> loadConfiguration("sqlite-type-mismatch.yaml",
+                        sqliteConnectionsYaml("type: mysql\n  url: jdbc:sqlite:/tmp/source.db\n  username: root\n",
+                                "type: sqlite\n  url: jdbc:sqlite:/tmp/target.db\n")));
+
+        assertTrue(exception.getMessage().contains("source.type does not match source.url"));
+    }
+
+    @Test
+    void shouldAllowSqliteInMemoryUrl() throws Exception {
+        CliConfiguration config = loadConfiguration("sqlite-memory.yaml",
+                sqliteConnectionsYaml("type: sqlite\n  url: \"jdbc:sqlite::memory:\"\n",
+                        "type: sqlite\n  url: jdbc:sqlite:/tmp/target.db\n"));
+
+        assertEquals("jdbc:sqlite::memory:", config.getSource().getUrl());
+    }
+
+    @Test
+    void shouldFailWhenSqliteUrlHasNoDataSource() throws Exception {
+        ConfigurationException exception = assertThrows(ConfigurationException.class,
+                () -> loadConfiguration("sqlite-empty-datasource.yaml",
+                        sqliteConnectionsYaml("type: sqlite\n  url: \"jdbc:sqlite:\"\n",
+                                "type: sqlite\n  url: jdbc:sqlite:/tmp/target.db\n")));
+
+        assertTrue(exception.getMessage().contains("source.url must include a SQLite data source path or :memory:"));
+    }
+
+    private CliConfiguration loadConfiguration(String fileName, String content) throws Exception {
+        Path configFile = tempDir.resolve(fileName);
+        Files.writeString(configFile, content);
+        return new ConfigurationManager().loadConfiguration(configFile.toString(), false);
+    }
+
+    private String sqliteConnectionsYaml(String sourceBlock, String targetBlock) {
+        return "source:\n"
+                + indent(sourceBlock)
+                + "target:\n"
+                + indent(targetBlock)
+                + "comparison:\n"
+                + "  tables:\n"
+                + "    source: orders\n"
+                + "    target: orders\n"
+                + "  keys:\n"
+                + "    source:\n"
+                + "      - id\n"
+                + "    target:\n"
+                + "      - id\n"
+                + "strategy:\n"
+                + "  mode: checksum\n"
+                + "  algorithm: xor\n";
+    }
+
+    private String indent(String block) {
+        String normalized = block.endsWith("\n") ? block.substring(0, block.length() - 1) : block;
+        String[] lines = normalized.split("\n");
+        StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append("  ").append(line.stripLeading()).append("\n");
+        }
+        return builder.toString();
+    }
 }

--- a/consilens-connector/consilens-connector-api/pom.xml
+++ b/consilens-connector/consilens-connector-api/pom.xml
@@ -23,6 +23,13 @@
             <artifactId>consilens-common</artifactId>
             <version>0.1-SNAPSHOT</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/ConnectionPoolOptimizer.java
+++ b/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/ConnectionPoolOptimizer.java
@@ -2,6 +2,8 @@ package com.consilens.connector.api;
 
 import com.consilens.connector.api.model.PoolConfiguration;
 
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Properties;
 
 /**
@@ -58,13 +60,28 @@ public interface ConnectionPoolOptimizer {
     Properties getOptimizationProperties(boolean useSSL);
 
     /**
+     * Initialize a newly acquired JDBC connection.
+     *
+     * <p>
+     * Dialects can override this hook to register database-specific SQL functions
+     * or apply other per-connection initialization that cannot be expressed via
+     * connectionInitSql alone.
+     *
+     * @param connection the newly acquired JDBC connection
+     * @throws SQLException if initialization fails
+     */
+    default void initializeConnection(Connection connection) throws SQLException {
+        // Default no-op.
+    }
+
+    /**
      * Get default connection pool configuration for this database type.
-     * 
+     *
      * <p>
      * This method returns a PoolConfiguration with database-specific defaults
      * for pool sizing, timeouts, and validation queries. The configuration
      * is optimized for the specific characteristics of the database.
-     * 
+     *
      * @return default PoolConfiguration for this database type
      */
     PoolConfiguration getDefaultConfiguration();

--- a/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/enums/DatabaseType.java
+++ b/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/enums/DatabaseType.java
@@ -377,9 +377,11 @@ public enum DatabaseType {
             return UNKNOWN;
         }
 
-        String lowerUrl = jdbcUrl.toLowerCase();
-        
-        if (lowerUrl.contains("tidb") || (lowerUrl.contains("mysql") && lowerUrl.contains(":4000"))) {
+        String lowerUrl = jdbcUrl.trim().toLowerCase();
+
+        if (lowerUrl.startsWith("jdbc:sqlite:")) {
+            return SQLITE;
+        } else if (lowerUrl.contains("tidb") || (lowerUrl.contains("mysql") && lowerUrl.contains(":4000"))) {
             return TIDB;
         } else if (lowerUrl.contains("doris")) {
             return DORIS;
@@ -393,8 +395,6 @@ public enum DatabaseType {
             return ORACLE;
         } else if (lowerUrl.contains("sqlserver")) {
             return SQL_SERVER;
-        } else if (lowerUrl.contains("sqlite")) {
-            return SQLITE;
         } else if (lowerUrl.contains("h2")) {
             return H2;
         } else if (lowerUrl.contains("snowflake")) {

--- a/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/model/PoolConfiguration.java
+++ b/consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/model/PoolConfiguration.java
@@ -45,7 +45,12 @@ public class PoolConfiguration {
         if (jdbcUrl == null || jdbcUrl.trim().isEmpty()) {
             throw new IllegalArgumentException("JDBC URL cannot be null or empty");
         }
-        if (username == null || username.trim().isEmpty()) {
+
+        DatabaseType effectiveType = databaseType == DatabaseType.UNKNOWN
+                ? DatabaseType.fromJdbcUrl(jdbcUrl)
+                : databaseType;
+
+        if (effectiveType != DatabaseType.SQLITE && (username == null || username.trim().isEmpty())) {
             throw new IllegalArgumentException("Username cannot be null or empty");
         }
         // Password can be null or empty string
@@ -65,7 +70,7 @@ public class PoolConfiguration {
 
         // Auto-detect database type if not set
         if (databaseType == DatabaseType.UNKNOWN) {
-            databaseType = DatabaseType.fromJdbcUrl(jdbcUrl);
+            databaseType = effectiveType;
         }
     }
 

--- a/consilens-connector/consilens-connector-api/src/test/java/com/consilens/connector/api/enums/DatabaseTypeTest.java
+++ b/consilens-connector/consilens-connector-api/src/test/java/com/consilens/connector/api/enums/DatabaseTypeTest.java
@@ -1,0 +1,20 @@
+package com.consilens.connector.api.enums;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatabaseTypeTest {
+
+    @Test
+    void shouldDetectSqliteOnlyFromJdbcSqlitePrefix() {
+        assertEquals(DatabaseType.SQLITE, DatabaseType.fromJdbcUrl("jdbc:sqlite:/tmp/source.db"));
+        assertEquals(DatabaseType.UNKNOWN, DatabaseType.fromJdbcUrl("jdbc:custom://localhost:9999/sqlite_demo"));
+    }
+
+    @Test
+    void shouldKeepRecognizingKnownJdbcSchemesEvenWhenPathContainsSqlite() {
+        assertEquals(DatabaseType.MYSQL, DatabaseType.fromJdbcUrl("jdbc:mysql://localhost:3306/sqlite_demo"));
+        assertEquals(DatabaseType.POSTGRESQL, DatabaseType.fromJdbcUrl("jdbc:postgresql://localhost:5432/sqlite_demo"));
+    }
+}

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-all/pom.xml
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-all/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>consilens-connector-doris</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.consilens</groupId>
+            <artifactId>consilens-connector-sqlite</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/pom.xml
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.consilens</groupId>
+        <artifactId>consilens-connector-plugins</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>consilens-connector-sqlite</artifactId>
+    <packaging>jar</packaging>
+    <name>Consilens Connector SQLite</name>
+    <description>SQLite database connector implementation</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.consilens</groupId>
+            <artifactId>consilens-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.30</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.44.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
@@ -1,5 +1,6 @@
 package com.consilens.connector.sqlite;
 
+import com.consilens.common.enums.ChecksumAlgorithm;
 import com.consilens.connector.api.CapabilityProvider;
 import com.consilens.connector.api.ConnectionPoolOptimizer;
 import com.consilens.connector.api.DataTypeHandler;
@@ -36,8 +37,8 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
 
     public SQLiteDatabaseDialect(Map<String, ?> normalizationConfig) {
         this.capabilityProvider = new SQLiteCapabilityProvider();
-        this.dataTypeHandler = new BaseDataTypeHandler(capabilityProvider, normalizationConfig);
-        this.sqlQueryGenerator = new SQLiteSqlQueryGenerator(capabilityProvider);
+        this.dataTypeHandler = new SQLiteDataTypeHandler(capabilityProvider, normalizationConfig);
+        this.sqlQueryGenerator = new SQLiteSqlQueryGenerator(capabilityProvider, dataTypeHandler);
         this.metadataQueryGenerator = new SQLiteMetadataQueryGenerator(capabilityProvider);
         this.connectionPoolOptimizer = new SQLiteConnectionPoolOptimizer();
     }
@@ -131,6 +132,183 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
         }
     }
 
+    private static final class SQLiteDataTypeHandler extends BaseDataTypeHandler {
+
+        private SQLiteDataTypeHandler(CapabilityProvider capabilityProvider, Map<String, ?> normalizationConfig) {
+            super(capabilityProvider, normalizationConfig);
+        }
+
+        @Override
+        protected String normalizeString(String quotedCol) {
+            return "COALESCE(TRIM(CAST(" + quotedCol + " AS TEXT)), '')";
+        }
+
+        @Override
+        protected String normalizeInteger(String quotedCol) {
+            return "COALESCE(TRIM(CAST(CAST(" + quotedCol + " AS INTEGER) AS TEXT)), '0')";
+        }
+
+        @Override
+        protected String normalizeDecimal(String quotedCol) {
+            return normalizeReal(quotedCol, getPrecision("decimal", 4), getRounding("decimal", true));
+        }
+
+        @Override
+        protected String normalizeFloat(String quotedCol) {
+            return normalizeReal(quotedCol, getPrecision("float", 6), getRounding("float", true));
+        }
+
+        @Override
+        protected String normalizeDate(String quotedCol) {
+            return "COALESCE(strftime('%Y-%m-%d', " + quotedCol + "), '')";
+        }
+
+        @Override
+        protected String normalizeTime(String quotedCol) {
+            return "COALESCE(strftime('%H:%M:%S', " + quotedCol + "), '')";
+        }
+
+        @Override
+        protected String normalizeDateTime(String quotedCol) {
+            return "COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + quotedCol + "), '')";
+        }
+
+        @Override
+        protected String normalizeTimestamp(String quotedCol) {
+            return normalizeDateTime(quotedCol);
+        }
+
+        @Override
+        protected String normalizeTimestampWithTimezone(String quotedCol) {
+            return normalizeDateTime(quotedCol);
+        }
+
+        @Override
+        protected String normalizeBoolean(String quotedCol) {
+            return "CASE WHEN LOWER(TRIM(CAST(" + quotedCol
+                    + " AS TEXT))) IN ('1', 'true', 't', 'y', 'yes') THEN '1' ELSE '0' END";
+        }
+
+        @Override
+        protected String normalizeBlob(String quotedCol) {
+            return "COALESCE(HEX(" + quotedCol + "), '')";
+        }
+
+        @Override
+        protected String normalizeJson(String quotedCol) {
+            return "COALESCE(CAST(" + quotedCol + " AS TEXT), '')";
+        }
+
+        @Override
+        protected String normalizeDefault(String quotedCol) {
+            return "COALESCE(TRIM(CAST(" + quotedCol + " AS TEXT)), '')";
+        }
+
+        @Override
+        public DataType convertToDataType(String sourceType) {
+            if (sourceType == null) {
+                return DataType.UNKNOWN;
+            }
+
+            String type = sourceType.toLowerCase().trim();
+            int parenIndex = type.indexOf('(');
+            if (parenIndex >= 0) {
+                type = type.substring(0, parenIndex).trim();
+            }
+
+            switch (type) {
+                case "int":
+                case "integer":
+                case "int4":
+                case "mediumint":
+                    return DataType.INTEGER;
+                case "tinyint":
+                    return DataType.TINYINT;
+                case "smallint":
+                case "int2":
+                    return DataType.SMALLINT;
+                case "bigint":
+                case "int8":
+                    return DataType.BIGINT;
+                case "decimal":
+                case "numeric":
+                case "dec":
+                    return DataType.DECIMAL;
+                case "float":
+                    return DataType.FLOAT;
+                case "real":
+                    return DataType.REAL;
+                case "double":
+                case "double precision":
+                    return DataType.DOUBLE;
+                case "char":
+                case "character":
+                case "nchar":
+                    return DataType.CHAR;
+                case "varchar":
+                case "character varying":
+                case "varying character":
+                case "nvarchar":
+                    return DataType.VARCHAR;
+                case "text":
+                case "clob":
+                    return DataType.TEXT;
+                case "date":
+                    return DataType.DATE;
+                case "time":
+                    return DataType.TIME;
+                case "timetz":
+                case "time with time zone":
+                    return DataType.TIME_WITH_TIME_ZONE;
+                case "datetime":
+                    return DataType.DATETIME;
+                case "timestamp":
+                    return DataType.TIMESTAMP;
+                case "timestamptz":
+                case "timestamp with time zone":
+                    return DataType.TIMESTAMP_WITH_TIMEZONE;
+                case "boolean":
+                case "bool":
+                    return DataType.BOOLEAN;
+                case "json":
+                    return DataType.JSON;
+                case "jsonb":
+                    return DataType.JSONB;
+                case "blob":
+                    return DataType.BLOB;
+                case "binary":
+                    return DataType.BINARY;
+                case "varbinary":
+                    return DataType.VARBINARY;
+                case "uuid":
+                    return DataType.UUID;
+                default:
+                    return super.convertToDataType(sourceType);
+            }
+        }
+
+        private String normalizeReal(String quotedCol, int precision, boolean rounding) {
+            if (precision == 0) {
+                String numericExpression = rounding
+                        ? "ROUND(CAST(" + quotedCol + " AS REAL), 0)"
+                        : "CAST(CAST(" + quotedCol + " AS REAL) AS INTEGER)";
+                return "COALESCE(TRIM(CAST(" + numericExpression + " AS TEXT)), '0')";
+            }
+
+            String scale = "1" + "0".repeat(precision);
+            String format = "% ." + precision + "f";
+            String defaultValue = "0." + "0".repeat(precision);
+            String integerSuffix = "." + "0".repeat(precision);
+            String numericExpression = rounding
+                    ? "ROUND(CAST(" + quotedCol + " AS REAL), " + precision + ")"
+                    : "(CAST((CAST(" + quotedCol + " AS REAL) * " + scale + ") AS INTEGER) / " + scale + ".0)";
+
+            return "CASE WHEN " + quotedCol + " IS NULL THEN '" + defaultValue + "' "
+                    + "WHEN typeof(" + quotedCol + ") = 'integer' THEN CAST(CAST(" + quotedCol + " AS INTEGER) AS TEXT) || '"
+                    + integerSuffix + "' ELSE printf('" + format.replace(" ", "") + "', " + numericExpression + ") END";
+        }
+    }
+
     private static final class SQLiteMetadataQueryGenerator extends BaseMetadataQueryGenerator {
         private final CapabilityProvider capabilityProvider;
 
@@ -218,8 +396,13 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
 
     private static final class SQLiteSqlQueryGenerator extends BaseSqlQueryGenerator {
 
-        private SQLiteSqlQueryGenerator(CapabilityProvider capabilityProvider) {
+        private final CapabilityProvider capabilityProvider;
+        private final DataTypeHandler dataTypeHandler;
+
+        private SQLiteSqlQueryGenerator(CapabilityProvider capabilityProvider, DataTypeHandler dataTypeHandler) {
             super(capabilityProvider);
+            this.capabilityProvider = capabilityProvider;
+            this.dataTypeHandler = dataTypeHandler;
         }
 
         @Override
@@ -228,8 +411,9 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
                                      List<String> columns,
                                      Map<String, DataType> columnDataTypes,
                                      String whereClause,
-                                     com.consilens.common.enums.ChecksumAlgorithm checksumAlgorithm) {
-            throw new UnsupportedOperationException("SQLite checksum SQL generation is not implemented");
+                                     ChecksumAlgorithm checksumAlgorithm) {
+            throw new UnsupportedOperationException(
+                    "SQLite checksum SQL generation is not supported because SQLite hashes are computed in code");
         }
 
         @Override
@@ -238,7 +422,45 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
                                     List<String> columns,
                                     Map<String, DataType> columnDataTypes,
                                     String whereClause) {
-            throw new UnsupportedOperationException("SQLite row hash SQL generation is not implemented");
+            throw new UnsupportedOperationException(
+                    "SQLite row-hash SQL generation is not supported because SQLite hashes are computed in code");
+        }
+
+        private void appendTableReference(StringBuilder sql, String schemaName, String tableName) {
+            if (schemaName != null && !schemaName.trim().isEmpty()) {
+                sql.append(capabilityProvider.quote(schemaName)).append('.');
+            }
+            sql.append(capabilityProvider.quote(tableName));
+        }
+
+        private void appendWhereClause(StringBuilder sql, String whereClause) {
+            if (whereClause != null && !whereClause.trim().isEmpty()) {
+                sql.append(" WHERE ").append(whereClause);
+            }
+        }
+
+        private String buildKeyExpression(List<String> keyColumns, Map<String, DataType> columnDataTypes) {
+            if (keyColumns == null || keyColumns.isEmpty()) {
+                return "'1'";
+            }
+            return buildDelimitedExpression(keyColumns, columnDataTypes);
+        }
+
+        private String buildDelimitedExpression(List<String> columns, Map<String, DataType> columnDataTypes) {
+            if (columns == null || columns.isEmpty()) {
+                return "''";
+            }
+
+            StringBuilder expression = new StringBuilder();
+            for (int i = 0; i < columns.size(); i++) {
+                if (i > 0) {
+                    expression.append(" || '|' || ");
+                }
+                String column = columns.get(i);
+                DataType dataType = columnDataTypes == null ? null : columnDataTypes.get(column);
+                expression.append(dataTypeHandler.normalizeColumn(column, dataType));
+            }
+            return expression.toString();
         }
     }
 
@@ -262,5 +484,6 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
             config.setValidationQuery("SELECT 1");
             return config;
         }
+
     }
 }

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
@@ -1,0 +1,266 @@
+package com.consilens.connector.sqlite;
+
+import com.consilens.connector.api.CapabilityProvider;
+import com.consilens.connector.api.ConnectionPoolOptimizer;
+import com.consilens.connector.api.DataTypeHandler;
+import com.consilens.connector.api.MetadataQueryGenerator;
+import com.consilens.connector.api.SqlQueryGenerator;
+import com.consilens.connector.api.enums.DatabaseFeature;
+import com.consilens.connector.api.enums.DatabaseType;
+import com.consilens.connector.api.model.DataType;
+import com.consilens.connector.api.model.PoolConfiguration;
+import com.consilens.conncetor.base.AbstractDatabaseDialect;
+import com.consilens.conncetor.base.BaseConnectionPoolOptimizer;
+import com.consilens.conncetor.base.BaseDataTypeHandler;
+import com.consilens.conncetor.base.BaseMetadataQueryGenerator;
+import com.consilens.conncetor.base.BaseSqlQueryGenerator;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
+
+    private final CapabilityProvider capabilityProvider;
+    private final DataTypeHandler dataTypeHandler;
+    private final SqlQueryGenerator sqlQueryGenerator;
+    private final MetadataQueryGenerator metadataQueryGenerator;
+    private final ConnectionPoolOptimizer connectionPoolOptimizer;
+
+    public SQLiteDatabaseDialect() {
+        this(null);
+    }
+
+    public SQLiteDatabaseDialect(Map<String, ?> normalizationConfig) {
+        this.capabilityProvider = new SQLiteCapabilityProvider();
+        this.dataTypeHandler = new BaseDataTypeHandler(capabilityProvider, normalizationConfig);
+        this.sqlQueryGenerator = new SQLiteSqlQueryGenerator(capabilityProvider);
+        this.metadataQueryGenerator = new SQLiteMetadataQueryGenerator(capabilityProvider);
+        this.connectionPoolOptimizer = new SQLiteConnectionPoolOptimizer();
+    }
+
+    @Override
+    public DatabaseType getDatabaseType() {
+        return DatabaseType.SQLITE;
+    }
+
+    @Override
+    public CapabilityProvider getCapabilityProvider() {
+        return capabilityProvider;
+    }
+
+    @Override
+    public SqlQueryGenerator getSqlQueryGenerator() {
+        return sqlQueryGenerator;
+    }
+
+    @Override
+    public MetadataQueryGenerator getMetadataQueryGenerator() {
+        return metadataQueryGenerator;
+    }
+
+    @Override
+    public DataTypeHandler getDataTypeHandler() {
+        return dataTypeHandler;
+    }
+
+    @Override
+    public ConnectionPoolOptimizer getConnectionPoolOptimizer() {
+        return connectionPoolOptimizer;
+    }
+
+    private static final class SQLiteCapabilityProvider implements CapabilityProvider {
+
+        private static final Set<DatabaseFeature> SUPPORTED_FEATURES = Collections.unmodifiableSet(
+                EnumSet.of(DatabaseFeature.TRANSACTIONS, DatabaseFeature.SAVEPOINTS));
+
+        @Override
+        public boolean supportsFeature(DatabaseFeature feature) {
+            return SUPPORTED_FEATURES.contains(feature);
+        }
+
+        @Override
+        public Set<DatabaseFeature> getSupportedFeatures() {
+            return SUPPORTED_FEATURES;
+        }
+
+        @Override
+        public String getDefaultSchema() {
+            return "main";
+        }
+
+        @Override
+        public String getCatalogSeparator() {
+            return ".";
+        }
+
+        @Override
+        public boolean supportsSchemas() {
+            return false;
+        }
+
+        @Override
+        public String getPaginationHint(long offset, long limit) {
+            return "";
+        }
+
+        @Override
+        public char getWildcardEscapeChar() {
+            return '\\';
+        }
+
+        @Override
+        public String escapePattern(String pattern) {
+            if (pattern == null) {
+                return null;
+            }
+            return pattern.replace("'", "''");
+        }
+
+        @Override
+        public String getOpenQuote() {
+            return "\"";
+        }
+
+        @Override
+        public String getCloseQuote() {
+            return "\"";
+        }
+    }
+
+    private static final class SQLiteMetadataQueryGenerator extends BaseMetadataQueryGenerator {
+        private final CapabilityProvider capabilityProvider;
+
+        private SQLiteMetadataQueryGenerator(CapabilityProvider capabilityProvider) {
+            super(capabilityProvider);
+            this.capabilityProvider = capabilityProvider;
+        }
+
+        @Override
+        public String getTableExistsSQL(String schemaName, String tableName) {
+            return "SELECT COUNT(*) FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?";
+        }
+
+        @Override
+        public String getColumnExistsSQL(String schemaName, String tableName, String columnName) {
+            return "SELECT COUNT(*) FROM pragma_table_info('" + escapeIdentifier(tableName) + "') WHERE name = ?";
+        }
+
+        @Override
+        public String getPrimaryKeySQL(String schemaName, String tableName) {
+            return "SELECT name FROM pragma_table_info('" + escapeIdentifier(tableName) + "') WHERE pk > 0 ORDER BY pk";
+        }
+
+        @Override
+        public String getTableColumnsSQL(String schemaName, String tableName) {
+            return "SELECT name AS column_name, type AS data_type, CASE WHEN \"notnull\" = 0 THEN 'YES' ELSE 'NO' END AS is_nullable, "
+                    + "NULL AS character_maximum_length, NULL AS numeric_precision, NULL AS numeric_scale, "
+                    + "NULL AS datetime_precision, dflt_value AS column_default "
+                    + "FROM pragma_table_info('" + escapeIdentifier(tableName) + "') ORDER BY cid";
+        }
+
+        @Override
+        public String getPrimaryKeysSQL(String schemaName, String tableName) {
+            return "SELECT name AS column_name, pk AS ordinal_position FROM pragma_table_info('"
+                    + escapeIdentifier(tableName) + "') WHERE pk > 0 ORDER BY pk";
+        }
+
+        @Override
+        public String getForeignKeysSQL(String schemaName, String tableName) {
+            return "SELECT \"from\" AS column_name, '' AS foreign_table_schema, \"table\" AS foreign_table_name, \"to\" AS foreign_column_name "
+                    + "FROM pragma_foreign_key_list('" + escapeIdentifier(tableName) + "')";
+        }
+
+        @Override
+        public String getIndexesSQL(String schemaName, String tableName) {
+            return "SELECT il.name AS index_name, ii.name AS column_name, CASE WHEN il.unique = 1 THEN 0 ELSE 1 END AS non_unique "
+                    + "FROM pragma_index_list('" + escapeIdentifier(tableName) + "') il "
+                    + "JOIN pragma_index_info(il.name) ii ORDER BY il.name, ii.seqno";
+        }
+
+        @Override
+        public String getDatabaseMetadataSQL() {
+            return "SELECT sqlite_version() AS version";
+        }
+
+        @Override
+        public String getSchemasSQL() {
+            return "SELECT 'main' AS schema_name";
+        }
+
+        @Override
+        public String getTablesSQL(String schemaName) {
+            return "SELECT name AS table_name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name";
+        }
+
+        @Override
+        public String getViewsSQL(String schemaName) {
+            return "SELECT name AS table_name FROM sqlite_master WHERE type = 'view' ORDER BY name";
+        }
+
+        @Override
+        public String getAnalyzeTableSQL(String schemaName, String tableName) {
+            return "ANALYZE " + capabilityProvider.quote(tableName);
+        }
+
+        @Override
+        public String getOptimizeTableSQL(String schemaName, String tableName) {
+            return getAnalyzeTableSQL(schemaName, tableName);
+        }
+
+        private String escapeIdentifier(String identifier) {
+            return identifier == null ? "" : identifier.replace("'", "''");
+        }
+    }
+
+    private static final class SQLiteSqlQueryGenerator extends BaseSqlQueryGenerator {
+
+        private SQLiteSqlQueryGenerator(CapabilityProvider capabilityProvider) {
+            super(capabilityProvider);
+        }
+
+        @Override
+        public String getChecksumSQL(String schemaName, String tableName,
+                                     List<String> keyColumns,
+                                     List<String> columns,
+                                     Map<String, DataType> columnDataTypes,
+                                     String whereClause,
+                                     com.consilens.common.enums.ChecksumAlgorithm checksumAlgorithm) {
+            throw new UnsupportedOperationException("SQLite checksum SQL generation is not implemented");
+        }
+
+        @Override
+        public String getRowHashSQL(String schemaName, String tableName,
+                                    List<String> primaryKeys,
+                                    List<String> columns,
+                                    Map<String, DataType> columnDataTypes,
+                                    String whereClause) {
+            throw new UnsupportedOperationException("SQLite row hash SQL generation is not implemented");
+        }
+    }
+
+    private static final class SQLiteConnectionPoolOptimizer extends BaseConnectionPoolOptimizer {
+
+        @Override
+        public Properties getOptimizationProperties(boolean useSSL) {
+            return new Properties();
+        }
+
+        @Override
+        public PoolConfiguration getDefaultConfiguration() {
+            PoolConfiguration config = new PoolConfiguration();
+            config.setDatabaseType(DatabaseType.SQLITE);
+            config.setMaxPoolSize(1);
+            config.setMinIdle(1);
+            config.setMaxLifetime(0);
+            config.setIdleTimeout(0);
+            config.setConnectionTimeout(30000);
+            config.setLeakDetectionThreshold(0);
+            config.setValidationQuery("SELECT 1");
+            return config;
+        }
+    }
+}

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialect.java
@@ -170,17 +170,116 @@ public class SQLiteDatabaseDialect extends AbstractDatabaseDialect {
 
         @Override
         protected String normalizeDateTime(String quotedCol) {
-            return "COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + quotedCol + "), '')";
+            return normalizeLiteralDateTime(quotedCol);
         }
 
         @Override
         protected String normalizeTimestamp(String quotedCol) {
-            return normalizeDateTime(quotedCol);
+            return normalizeTimestampValue(quotedCol);
         }
 
         @Override
         protected String normalizeTimestampWithTimezone(String quotedCol) {
-            return normalizeDateTime(quotedCol);
+            return normalizeTimestampValue(quotedCol);
+        }
+
+        private String normalizeLiteralDateTime(String quotedCol) {
+            String textValue = normalizeTemporalText(quotedCol);
+            String literalText = stripFraction(stripExplicitTimezone(textValue));
+            String numericTemporal = normalizeNumericTemporal(quotedCol);
+            return "CASE WHEN " + quotedCol + " IS NULL THEN '' "
+                    + "WHEN " + isNumericTemporal(quotedCol) + " THEN " + numericTemporal + " "
+                    + "ELSE " + normalizeLiteralDateTimeText(literalText) + " END";
+        }
+
+        private String normalizeTimestampValue(String quotedCol) {
+            String textValue = normalizeTemporalText(quotedCol);
+            String parseableTimestamp = normalizeParseableTimestampText(textValue);
+            String literalText = stripFraction(stripExplicitTimezone(textValue));
+            String numericTemporal = normalizeNumericTemporal(quotedCol);
+            return "CASE WHEN " + quotedCol + " IS NULL THEN '' "
+                    + "WHEN " + isNumericTemporal(quotedCol) + " THEN " + numericTemporal + " "
+                    + "WHEN " + hasExplicitTimezone(textValue) + " THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + parseableTimestamp + ", 'utc'), '') "
+                    + "ELSE " + normalizeLiteralDateTimeText(literalText) + " END";
+        }
+
+        private String normalizeLiteralDateTimeText(String literalText) {
+            return "CASE WHEN " + literalText + " = '' THEN '' "
+                    + "WHEN " + literalText + " GLOB '????-??-??' THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + literalText + " || ' 00:00:00'), '') "
+                    + "WHEN " + literalText + " GLOB '????-??-?? ??:??' THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + literalText + " || ':00'), '') "
+                    + "WHEN " + literalText + " GLOB '????-??-?? ??:??:??' THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + literalText + "), '') "
+                    + "ELSE '' END";
+        }
+
+        private String normalizeTemporalText(String quotedCol) {
+            return "REPLACE(TRIM(CAST(" + quotedCol + " AS TEXT)), 'T', ' ')";
+        }
+
+        private String normalizeNumericTemporal(String quotedCol) {
+            return "CASE WHEN typeof(" + quotedCol + ") = 'integer' THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + quotedCol + ", 'unixepoch'), '') "
+                    + "WHEN typeof(" + quotedCol + ") = 'real' THEN COALESCE(strftime('%Y-%m-%d %H:%M:%S', " + quotedCol + "), '') "
+                    + "ELSE '' END";
+        }
+
+        private String isNumericTemporal(String quotedCol) {
+            return "typeof(" + quotedCol + ") IN ('integer', 'real')";
+        }
+
+        private String normalizeParseableTimestampText(String textValue) {
+            return "CASE WHEN " + hasCompactTimezone(textValue) + " THEN SUBSTR(" + textValue + ", 1, LENGTH(" + textValue + ") - 2) || ':' || SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 1, 2) "
+                    + "ELSE " + textValue + " END";
+        }
+
+        private String stripExplicitTimezone(String textValue) {
+            return "CASE WHEN " + hasZuluTimezone(textValue) + " THEN SUBSTR(" + textValue + ", 1, LENGTH(" + textValue + ") - 1) "
+                    + "WHEN " + hasColonTimezone(textValue) + " THEN SUBSTR(" + textValue + ", 1, LENGTH(" + textValue + ") - 6) "
+                    + "WHEN " + hasCompactTimezone(textValue) + " THEN SUBSTR(" + textValue + ", 1, LENGTH(" + textValue + ") - 5) "
+                    + "ELSE " + textValue + " END";
+        }
+
+        private String stripFraction(String textValue) {
+            String fractionalPart = "SUBSTR(" + textValue + ", 21)";
+            return "CASE WHEN " + hasNumericFraction(textValue, fractionalPart) + " THEN SUBSTR(" + textValue + ", 1, 19) "
+                    + "ELSE " + textValue + " END";
+        }
+
+        private String hasNumericFraction(String textValue, String fractionalPart) {
+            return textValue + " GLOB '????-??-?? ??:??:??.*' "
+                    + "AND LENGTH(" + fractionalPart + ") > 0 "
+                    + "AND TRIM(" + fractionalPart + ", '0123456789') = ''";
+        }
+
+        private String hasExplicitTimezone(String textValue) {
+            return hasZuluTimezone(textValue)
+                    + " OR " + hasColonTimezone(textValue)
+                    + " OR " + hasCompactTimezone(textValue);
+        }
+
+        private String hasZuluTimezone(String textValue) {
+            return textValue + " LIKE '%Z'";
+        }
+
+        private String hasColonTimezone(String textValue) {
+            String hourPart = "SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 4, 2)";
+            String minutePart = "SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 1, 2)";
+            return "LENGTH(" + textValue + ") >= 6 "
+                    + "AND SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 5, 1) IN ('+', '-') "
+                    + "AND " + hourPart + " GLOB '[0-9][0-9]' "
+                    + "AND CAST(" + hourPart + " AS INTEGER) BETWEEN 0 AND 23 "
+                    + "AND SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 2, 1) = ':' "
+                    + "AND " + minutePart + " GLOB '[0-9][0-9]' "
+                    + "AND CAST(" + minutePart + " AS INTEGER) BETWEEN 0 AND 59";
+        }
+
+        private String hasCompactTimezone(String textValue) {
+            String hourPart = "SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 3, 2)";
+            String minutePart = "SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 1, 2)";
+            return "LENGTH(" + textValue + ") >= 5 "
+                    + "AND SUBSTR(" + textValue + ", LENGTH(" + textValue + ") - 4, 1) IN ('+', '-') "
+                    + "AND " + hourPart + " GLOB '[0-9][0-9]' "
+                    + "AND CAST(" + hourPart + " AS INTEGER) BETWEEN 0 AND 23 "
+                    + "AND " + minutePart + " GLOB '[0-9][0-9]' "
+                    + "AND CAST(" + minutePart + " AS INTEGER) BETWEEN 0 AND 59";
         }
 
         @Override

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectProvider.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectProvider.java
@@ -1,0 +1,25 @@
+package com.consilens.connector.sqlite;
+
+import com.consilens.connector.api.DatabaseDialect;
+import com.consilens.connector.api.DatabaseDialectProvider;
+import com.consilens.connector.api.enums.DatabaseType;
+
+import java.util.Map;
+
+public class SQLiteDatabaseDialectProvider implements DatabaseDialectProvider {
+
+    @Override
+    public DatabaseType getDatabaseType() {
+        return DatabaseType.SQLITE;
+    }
+
+    @Override
+    public DatabaseDialect create() {
+        return new SQLiteDatabaseDialect();
+    }
+
+    @Override
+    public DatabaseDialect create(Map<String, ?> normalizationConfig) {
+        return new SQLiteDatabaseDialect(normalizationConfig);
+    }
+}

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/resources/META-INF/services/com.consilens.connector.api.DatabaseDialectProvider
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/main/resources/META-INF/services/com.consilens.connector.api.DatabaseDialectProvider
@@ -1,0 +1,1 @@
+com.consilens.connector.sqlite.SQLiteDatabaseDialectProvider

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -62,10 +63,154 @@ class SQLiteDatabaseDialectTest {
                 dialect.getDataTypeHandler().normalizeColumn("id", DataType.INTEGER));
         assertEquals("CASE WHEN LOWER(TRIM(CAST(\"is_active\" AS TEXT))) IN ('1', 'true', 't', 'y', 'yes') THEN '1' ELSE '0' END",
                 dialect.getDataTypeHandler().normalizeColumn("is_active", DataType.BOOLEAN));
-        assertEquals("COALESCE(strftime('%Y-%m-%d %H:%M:%S', \"created_at\"), '')",
+        String normalizedDateTime = dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.DATETIME);
+        String normalizedTimestamp = dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.TIMESTAMP);
+        String normalizedTimestampWithTimezone = dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.TIMESTAMP_WITH_TIMEZONE);
+
+        assertTrue(normalizedDateTime.contains("CASE WHEN \"created_at\" IS NULL THEN ''"));
+        assertTrue(normalizedDateTime.contains("GLOB '????-??-?? ??:??:??'"));
+        assertTrue(normalizedTimestamp.contains("strftime('%Y-%m-%d %H:%M:%S'"));
+        assertTrue(normalizedTimestamp.contains("'utc'"));
+        assertTrue(normalizedTimestamp.contains("LIKE '%Z'"));
+        assertTrue(normalizedTimestamp.contains("typeof(\"created_at\") IN ('integer', 'real')"));
+        assertTrue(normalizedTimestamp.contains("BETWEEN 0 AND 23"));
+        assertTrue(normalizedTimestamp.contains("BETWEEN 0 AND 59"));
+        assertEquals(normalizedTimestamp, normalizedTimestampWithTimezone);
+        assertNotEquals(
+                dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.DATETIME),
                 dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.TIMESTAMP));
         assertEquals("COALESCE(HEX(\"payload\"), '')",
                 dialect.getDataTypeHandler().normalizeColumn("payload", DataType.BLOB));
+    }
+
+    @Test
+    void shouldNormalizeSqliteTemporalTypesWithExpectedTimezoneSemantics() throws Exception {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE sample (datetime_col TEXT, timestamp_col TEXT, timestamptz_col TEXT, naive_timestamp_col TEXT, minute_datetime_col TEXT, invalid_datetime_col TEXT, compact_timestamp_col TEXT, garbage_suffix_datetime_col TEXT, minute_z_timestamp_col TEXT)");
+            statement.execute("INSERT INTO sample(datetime_col, timestamp_col, timestamptz_col, naive_timestamp_col, minute_datetime_col, invalid_datetime_col, compact_timestamp_col, garbage_suffix_datetime_col, minute_z_timestamp_col) VALUES ("
+                    + "'2026-04-14 08:09:10+08:00', "
+                    + "'2026-04-14 08:09:10+08:00', "
+                    + "'2026-04-14 08:09:10+08:00', "
+                    + "'2026-04-14 08:09:10', "
+                    + "'2026-04-14 08:09', "
+                    + "'not-a-date', "
+                    + "'2026-04-14 08:09:10+0800', "
+                    + "'2026-04-14 08:09:10foo', "
+                    + "'2026-04-14 08:09Z')");
+
+            String query = "SELECT "
+                    + dialect.getDataTypeHandler().normalizeColumn("datetime_col", DataType.DATETIME) + " AS normalized_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("timestamp_col", DataType.TIMESTAMP) + " AS normalized_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("timestamptz_col", DataType.TIMESTAMP_WITH_TIMEZONE) + " AS normalized_timestamptz, "
+                    + dialect.getDataTypeHandler().normalizeColumn("naive_timestamp_col", DataType.TIMESTAMP) + " AS normalized_naive_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("minute_datetime_col", DataType.DATETIME) + " AS normalized_minute_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("invalid_datetime_col", DataType.DATETIME) + " AS normalized_invalid_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("compact_timestamp_col", DataType.TIMESTAMP) + " AS normalized_compact_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("garbage_suffix_datetime_col", DataType.DATETIME) + " AS normalized_garbage_suffix_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("minute_z_timestamp_col", DataType.TIMESTAMP) + " AS normalized_minute_z_timestamp "
+                    + "FROM sample";
+
+            try (ResultSet resultSet = statement.executeQuery(query)) {
+                assertTrue(resultSet.next());
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_datetime"));
+                assertEquals("2026-04-14 00:09:10", resultSet.getString("normalized_timestamp"));
+                assertEquals("2026-04-14 00:09:10", resultSet.getString("normalized_timestamptz"));
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_naive_timestamp"));
+                assertEquals("2026-04-14 08:09:00", resultSet.getString("normalized_minute_datetime"));
+                assertEquals("", resultSet.getString("normalized_invalid_datetime"));
+                assertEquals("2026-04-14 00:09:10", resultSet.getString("normalized_compact_timestamp"));
+                assertEquals("", resultSet.getString("normalized_garbage_suffix_datetime"));
+                assertEquals("2026-04-14 08:09:00", resultSet.getString("normalized_minute_z_timestamp"));
+            }
+        }
+    }
+
+    @Test
+    void shouldRejectMalformedTemporalSuffixesAndSupportJulianDayValues() throws Exception {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE sample (malformed_fraction_col TEXT, real_julian_datetime_col REAL, real_julian_timestamp_col REAL, invalid_timezone_datetime_col TEXT, valid_fraction_datetime_col TEXT, epoch_datetime_col INTEGER, epoch_timestamp_col INTEGER, epoch_zero_datetime_col INTEGER, epoch_day_timestamp_col INTEGER, negative_epoch_datetime_col INTEGER)");
+            statement.execute("INSERT INTO sample(malformed_fraction_col, real_julian_datetime_col, real_julian_timestamp_col, invalid_timezone_datetime_col, valid_fraction_datetime_col, epoch_datetime_col, epoch_timestamp_col, epoch_zero_datetime_col, epoch_day_timestamp_col, negative_epoch_datetime_col) VALUES ("
+                    + "'2026-04-14 08:09:10.abc', "
+                    + "julianday('2026-04-14 08:09:10'), "
+                    + "julianday('2026-04-14 08:09:10'), "
+                    + "'2026-04-14 08:09:10+99:99', "
+                    + "'2026-04-14 08:09:10.123', "
+                    + "1713082150, "
+                    + "1713082150, "
+                    + "0, "
+                    + "86400, "
+                    + "-1)");
+
+            String textAndJulianQuery = "SELECT "
+                    + dialect.getDataTypeHandler().normalizeColumn("malformed_fraction_col", DataType.TIMESTAMP) + " AS normalized_malformed_fraction, "
+                    + dialect.getDataTypeHandler().normalizeColumn("real_julian_datetime_col", DataType.DATETIME) + " AS normalized_real_julian_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("real_julian_timestamp_col", DataType.TIMESTAMP) + " AS normalized_real_julian_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("invalid_timezone_datetime_col", DataType.DATETIME) + " AS normalized_invalid_timezone_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("valid_fraction_datetime_col", DataType.DATETIME) + " AS normalized_valid_fraction_datetime "
+                    + "FROM sample";
+
+            try (ResultSet resultSet = statement.executeQuery(textAndJulianQuery)) {
+                assertTrue(resultSet.next());
+                assertEquals("", resultSet.getString("normalized_malformed_fraction"));
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_real_julian_datetime"));
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_real_julian_timestamp"));
+                assertEquals("", resultSet.getString("normalized_invalid_timezone_datetime"));
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_valid_fraction_datetime"));
+            }
+
+            String epochQuery = "SELECT "
+                    + dialect.getDataTypeHandler().normalizeColumn("epoch_datetime_col", DataType.DATETIME) + " AS normalized_epoch_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("epoch_timestamp_col", DataType.TIMESTAMP) + " AS normalized_epoch_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("epoch_zero_datetime_col", DataType.DATETIME) + " AS normalized_epoch_zero_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("epoch_day_timestamp_col", DataType.TIMESTAMP) + " AS normalized_epoch_day_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("negative_epoch_datetime_col", DataType.DATETIME) + " AS normalized_negative_epoch_datetime "
+                    + "FROM sample";
+
+            try (ResultSet resultSet = statement.executeQuery(epochQuery)) {
+                assertTrue(resultSet.next());
+                assertEquals("2024-04-14 08:09:10", resultSet.getString("normalized_epoch_datetime"));
+                assertEquals("2024-04-14 08:09:10", resultSet.getString("normalized_epoch_timestamp"));
+                assertEquals("1970-01-01 00:00:00", resultSet.getString("normalized_epoch_zero_datetime"));
+                assertEquals("1970-01-02 00:00:00", resultSet.getString("normalized_epoch_day_timestamp"));
+                assertEquals("1969-12-31 23:59:59", resultSet.getString("normalized_negative_epoch_datetime"));
+            }
+        }
+    }
+
+    @Test
+    void shouldNormalizeFractionalTimezoneTimestampsWithoutExpandingSqlTooMuch() throws Exception {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE sample (fractional_datetime_col TEXT, fractional_z_timestamp_col TEXT, fractional_colon_timestamp_col TEXT, fractional_compact_timestamp_col TEXT)");
+            statement.execute("INSERT INTO sample(fractional_datetime_col, fractional_z_timestamp_col, fractional_colon_timestamp_col, fractional_compact_timestamp_col) VALUES ("
+                    + "'2026-04-14 08:09:10.123+08:00', "
+                    + "'2026-04-14 08:09:10.123Z', "
+                    + "'2026-04-14 08:09:10.123+08:00', "
+                    + "'2026-04-14 08:09:10.123+0800')");
+
+            String query = "SELECT "
+                    + dialect.getDataTypeHandler().normalizeColumn("fractional_datetime_col", DataType.DATETIME) + " AS normalized_fractional_datetime, "
+                    + dialect.getDataTypeHandler().normalizeColumn("fractional_z_timestamp_col", DataType.TIMESTAMP) + " AS normalized_fractional_z_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("fractional_colon_timestamp_col", DataType.TIMESTAMP) + " AS normalized_fractional_colon_timestamp, "
+                    + dialect.getDataTypeHandler().normalizeColumn("fractional_compact_timestamp_col", DataType.TIMESTAMP) + " AS normalized_fractional_compact_timestamp "
+                    + "FROM sample";
+
+            try (ResultSet resultSet = statement.executeQuery(query)) {
+                assertTrue(resultSet.next());
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_fractional_datetime"));
+                assertEquals("2026-04-14 08:09:10", resultSet.getString("normalized_fractional_z_timestamp"));
+                assertEquals("2026-04-14 00:09:10", resultSet.getString("normalized_fractional_colon_timestamp"));
+                assertEquals("2026-04-14 00:09:10", resultSet.getString("normalized_fractional_compact_timestamp"));
+            }
+        }
     }
 
     @Test

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
@@ -1,14 +1,24 @@
 package com.consilens.connector.sqlite;
 
+import com.consilens.common.enums.ChecksumAlgorithm;
 import com.consilens.connector.api.DatabaseDialect;
 import com.consilens.connector.api.DatabaseDialectProvider;
 import com.consilens.connector.api.enums.DatabaseType;
+import com.consilens.connector.api.model.DataType;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.ServiceLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SQLiteDatabaseDialectTest {
@@ -31,14 +41,119 @@ class SQLiteDatabaseDialectTest {
 
         boolean found = false;
         for (DatabaseDialectProvider provider : loader) {
-            if (provider.getDatabaseType() == DatabaseType.SQLITE) {
+            if (provider.getDatabaseType() == com.consilens.connector.api.enums.DatabaseType.SQLITE) {
                 DatabaseDialect dialect = provider.create();
-                assertEquals(DatabaseType.SQLITE, dialect.getDatabaseType());
+                assertEquals(com.consilens.connector.api.enums.DatabaseType.SQLITE, dialect.getDatabaseType());
                 found = true;
                 break;
             }
         }
 
         assertTrue(found, "Expected SQLite provider to be discoverable via ServiceLoader");
+    }
+
+    @Test
+    void shouldNormalizeSharedScalarTypesExplicitlyForCompare() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        assertEquals("COALESCE(TRIM(CAST(\"name\" AS TEXT)), '')",
+                dialect.getDataTypeHandler().normalizeColumn("name", DataType.VARCHAR));
+        assertEquals("COALESCE(TRIM(CAST(CAST(\"id\" AS INTEGER) AS TEXT)), '0')",
+                dialect.getDataTypeHandler().normalizeColumn("id", DataType.INTEGER));
+        assertEquals("CASE WHEN LOWER(TRIM(CAST(\"is_active\" AS TEXT))) IN ('1', 'true', 't', 'y', 'yes') THEN '1' ELSE '0' END",
+                dialect.getDataTypeHandler().normalizeColumn("is_active", DataType.BOOLEAN));
+        assertEquals("COALESCE(strftime('%Y-%m-%d %H:%M:%S', \"created_at\"), '')",
+                dialect.getDataTypeHandler().normalizeColumn("created_at", DataType.TIMESTAMP));
+        assertEquals("COALESCE(HEX(\"payload\"), '')",
+                dialect.getDataTypeHandler().normalizeColumn("payload", DataType.BLOB));
+    }
+
+    @Test
+    void shouldMapSqliteDeclaredTypesNeededForCompare() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        assertEquals(DataType.INTEGER, dialect.getDataTypeHandler().convertToDataType("INTEGER"));
+        assertEquals(DataType.DECIMAL, dialect.getDataTypeHandler().convertToDataType("NUMERIC(10,2)"));
+        assertEquals(DataType.VARCHAR, dialect.getDataTypeHandler().convertToDataType("VARCHAR(64)"));
+        assertEquals(DataType.TIMESTAMP, dialect.getDataTypeHandler().convertToDataType("TIMESTAMP"));
+        assertEquals(DataType.BLOB, dialect.getDataTypeHandler().convertToDataType("BLOB"));
+    }
+
+    @Test
+    void shouldRejectChecksumSqlGenerationBecauseSqliteHashesAreComputedInCode() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+        Map<String, DataType> types = new HashMap<>();
+        types.put("id", DataType.INTEGER);
+        types.put("name", DataType.VARCHAR);
+        types.put("amount", DataType.DECIMAL);
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                () -> dialect.getSqlQueryGenerator().getChecksumSQL(
+                        null,
+                        "users",
+                        Arrays.asList("id"),
+                        Arrays.asList("id", "name", "amount"),
+                        types,
+                        "id >= 100",
+                        ChecksumAlgorithm.CONCAT));
+
+        assertTrue(exception.getMessage().contains("computed in code"));
+    }
+
+    @Test
+    void shouldPreserveExactIntegerMagnitudeWhenNormalizingDecimalValues() throws Exception {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+        String expression = dialect.getDataTypeHandler().normalizeColumn("amount", DataType.DECIMAL);
+
+        try (Connection connection = DriverManager.getConnection("jdbc:sqlite::memory:");
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE sample (amount NUMERIC)");
+            statement.execute("INSERT INTO sample(amount) VALUES (9007199254740993)");
+
+            try (ResultSet resultSet = statement.executeQuery("SELECT " + expression + " AS normalized_amount FROM sample")) {
+                assertTrue(resultSet.next());
+                assertEquals("9007199254740993.0000", resultSet.getString("normalized_amount"));
+            }
+        }
+    }
+
+    @Test
+    void shouldRejectXorChecksumSqlForSqlite() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+        Map<String, DataType> types = new HashMap<>();
+        types.put("id", DataType.INTEGER);
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                () -> dialect.getSqlQueryGenerator().getChecksumSQL(
+                        null,
+                        "users",
+                        Arrays.asList("id"),
+                        Arrays.asList("id"),
+                        types,
+                        null,
+                        ChecksumAlgorithm.XOR));
+
+        assertTrue(exception.getMessage().contains("computed in code"));
+    }
+
+    @Test
+    void shouldRejectRowHashSqlGenerationBecauseSqliteHashesAreComputedInCode() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+        Map<String, DataType> types = new HashMap<>();
+        types.put("tenant_id", DataType.INTEGER);
+        types.put("user_id", DataType.INTEGER);
+        types.put("name", DataType.VARCHAR);
+        types.put("created_at", DataType.TIMESTAMP);
+
+        UnsupportedOperationException exception = assertThrows(UnsupportedOperationException.class,
+                () -> dialect.getSqlQueryGenerator().getRowHashSQL(
+                        null,
+                        "users",
+                        Arrays.asList("tenant_id", "user_id"),
+                        Arrays.asList("tenant_id", "user_id", "name", "created_at"),
+                        types,
+                        "tenant_id = 9"));
+
+        assertTrue(exception.getMessage().contains("computed in code"));
     }
 }

--- a/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
+++ b/consilens-connector/consilens-connector-plugins/consilens-connector-sqlite/src/test/java/com/consilens/connector/sqlite/SQLiteDatabaseDialectTest.java
@@ -1,0 +1,44 @@
+package com.consilens.connector.sqlite;
+
+import com.consilens.connector.api.DatabaseDialect;
+import com.consilens.connector.api.DatabaseDialectProvider;
+import com.consilens.connector.api.enums.DatabaseType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ServiceLoader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SQLiteDatabaseDialectTest {
+
+    @Test
+    void shouldExposeSqliteDatabaseTypeAndValidationComponents() {
+        SQLiteDatabaseDialect dialect = new SQLiteDatabaseDialect();
+
+        assertEquals(DatabaseType.SQLITE, dialect.getDatabaseType());
+        assertNotNull(dialect.getConnectionPoolOptimizer());
+        assertNotNull(dialect.getCapabilityProvider());
+        assertNotNull(dialect.getMetadataQueryGenerator());
+        assertEquals("SELECT 1", dialect.getMetadataQueryGenerator().getHealthCheckSQL());
+        assertEquals("SELECT sqlite_version() AS version", dialect.getMetadataQueryGenerator().getDatabaseMetadataSQL());
+    }
+
+    @Test
+    void shouldLoadProviderViaServiceLoader() {
+        ServiceLoader<DatabaseDialectProvider> loader = ServiceLoader.load(DatabaseDialectProvider.class);
+
+        boolean found = false;
+        for (DatabaseDialectProvider provider : loader) {
+            if (provider.getDatabaseType() == DatabaseType.SQLITE) {
+                DatabaseDialect dialect = provider.create();
+                assertEquals(DatabaseType.SQLITE, dialect.getDatabaseType());
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue(found, "Expected SQLite provider to be discoverable via ServiceLoader");
+    }
+}

--- a/consilens-connector/consilens-connector-plugins/pom.xml
+++ b/consilens-connector/consilens-connector-plugins/pom.xml
@@ -31,6 +31,7 @@
         <module>consilens-connector-starrocks</module>
         <module>consilens-connector-clickhouse</module>
         <module>consilens-connector-tidb</module>
+        <module>consilens-connector-sqlite</module>
         <module>consilens-connector-all</module>
     </modules>
 

--- a/consilens-core/pom.xml
+++ b/consilens-core/pom.xml
@@ -126,14 +126,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- SQLite for testing -->
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.44.1.0</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>com.consilens</groupId>
             <artifactId>consilens-connector-all</artifactId>

--- a/consilens-core/src/main/java/com/consilens/core/database/adpter/AbstractDatabaseAdapter.java
+++ b/consilens-core/src/main/java/com/consilens/core/database/adpter/AbstractDatabaseAdapter.java
@@ -12,6 +12,9 @@ import com.consilens.core.segment.TableSegment;
 import com.consilens.core.util.ResourceManager;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -319,13 +322,15 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
     @Override
     public TableSegment.ChecksumResult countAndChecksum(TableSegment segment) {
         try {
-            // Build simple checksum query
+            if (shouldComputeHashesInCode()) {
+                return countAndChecksumInCode(segment);
+            }
+
             List<String> relevantColumns = segment.getRelevantColumns();
             String checksumQuery = buildChecksumQuery(segment, relevantColumns);
 
             log.info("Executing checksum query: {}", checksumQuery);
 
-            // Execute query using a RowMapper that returns Maps
             List<Map<String, Object>> results = query(checksumQuery, (rs, rowNum) -> {
                 Map<String, Object> row = new HashMap<>();
                 int columnCount = rs.getMetaData().getColumnCount();
@@ -345,7 +350,6 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
             long rowCount = ((Number) result.get("row_count")).longValue();
             String checksum = (String) result.get("checksum");
 
-            // Get min/max key values separately if needed
             List<Object> minKey = null;
             List<Object> maxKey = null;
             if (!segment.getKeyColumns().isEmpty()) {
@@ -355,6 +359,8 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
 
             return new TableSegment.ChecksumResult(rowCount, checksum, minKey, maxKey);
 
+        } catch (UnsupportedOperationException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Error calculating checksum for segment: {}", segment.getTablePath(), e);
             throw new RuntimeException("Checksum calculation failed", e);
@@ -415,16 +421,7 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
 
         // Extract column data types from the schema
         Map<String, DataType> columnDataTypes = new HashMap<>();
-        TableSchema tableSchema;
-        // If segment doesn't have schema, fetch it from database
-        if (segment.getSchema().isPresent()) {
-            tableSchema = segment.getSchema().get();
-        } else {
-            // Fetch schema from database
-            List<String> tablePathComponents = segment.getTablePath().getComponents();
-            tableSchema = getTableSchema(tablePathComponents);
-            segment.withSchema(tableSchema);
-        }
+        TableSchema tableSchema = resolveTableSchema(segment);
         // Now extract data types for all columns
         for (String column : columns) {
             DataType dataType = tableSchema.getColumnType(column);
@@ -619,9 +616,13 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
     @Override
     public Map<List<Object>, String> querySegmentRowHashes(TableSegment segment) {
         try {
+            if (shouldComputeHashesInCode()) {
+                return querySegmentRowHashesInCode(segment);
+            }
+
             String rowHashQuery = buildRowHashQuery(segment);
 
-            log.debug("Executing row hash query for segment: {}, keys: {}", 
+            log.debug("Executing row hash query for segment: {}, keys: {}",
                     segment.getTablePath(), segment.getKeyColumns().size());
 
             Map<List<Object>, String> rowHashes = new LinkedHashMap<>();
@@ -640,13 +641,11 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
                 int rowCount = 0;
 
                 while (resultSet.next()) {
-                    // Extract primary key values
                     List<Object> primaryKey = new ArrayList<>(keyColumnCount);
                     for (int i = 1; i <= keyColumnCount; i++) {
                         primaryKey.add(resultSet.getObject(i));
                     }
 
-                    // Extract row hash (last column)
                     String rowHash = resultSet.getString(resultSet.getMetaData().getColumnCount());
                     rowHashes.put(primaryKey, rowHash);
                     rowCount++;
@@ -1085,23 +1084,14 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
         List<String> columns = segment.getRelevantColumns();
         String whereClause = segment.buildWhereClause();
 
-        // Retrieve column data types
         Map<String, DataType> columnDataTypes = new HashMap<>();
-        TableSchema tableSchema;
-        if (segment.getSchema().isPresent()) {
-            tableSchema = segment.getSchema().get();
-        } else {
-            List<String> tablePathComponents = segment.getTablePath().getComponents();
-            tableSchema = getTableSchema(tablePathComponents);
-            segment.withSchema(tableSchema);
-        }
+        TableSchema tableSchema = resolveTableSchema(segment);
 
         for (String column : columns) {
             DataType dataType = tableSchema.getColumnType(column);
             columnDataTypes.put(column, dataType);
         }
 
-        // Log only table name, key/column counts, and where clause — not the full column list
         log.debug("Building row-hash query for table: {}, primaryKeys: {} columns, dataColumns: {} columns, where: {}",
                 tableName, primaryKeys.size(), columns.size(), whereClause != null ? "present" : "none");
 
@@ -1110,6 +1100,199 @@ public abstract class AbstractDatabaseAdapter implements DatabaseAdapter {
         log.info("Generated row-hash query: {}", sql);
 
         return sql;
+    }
+
+    protected boolean shouldComputeHashesInCode() {
+        return type == DatabaseType.SQLITE;
+    }
+
+    private TableSegment.ChecksumResult countAndChecksumInCode(TableSegment segment) {
+        if (checksumAlgorithm.isXor()) {
+            throw new UnsupportedOperationException("SQLite code-side checksum only supports CONCAT algorithm");
+        }
+
+        List<CodeSideRowHash> rowHashes = queryCodeSideRowHashes(segment);
+        long rowCount = rowHashes.size();
+        String checksum = computeSegmentChecksum(rowHashes);
+        List<String> keyColumns = segment.getKeyColumns();
+
+        List<Object> minKey = null;
+        List<Object> maxKey = null;
+        if (!keyColumns.isEmpty()) {
+            minKey = getMinMaxKey(segment, true);
+            maxKey = getMinMaxKey(segment, false);
+        }
+
+        return new TableSegment.ChecksumResult(rowCount, checksum, minKey, maxKey);
+    }
+
+    private Map<List<Object>, String> querySegmentRowHashesInCode(TableSegment segment) {
+        List<CodeSideRowHash> codeSideRowHashes = queryCodeSideRowHashes(segment);
+        Map<List<Object>, String> rowHashes = new LinkedHashMap<>();
+        for (CodeSideRowHash codeSideRowHash : codeSideRowHashes) {
+            rowHashes.put(codeSideRowHash.primaryKey(), codeSideRowHash.rowHash());
+        }
+        return rowHashes;
+    }
+
+    private List<CodeSideRowHash> queryCodeSideRowHashes(TableSegment segment) {
+        TableSchema schema = resolveTableSchema(segment);
+        List<String> keyColumns = segment.getKeyColumns();
+        List<String> relevantColumns = segment.getRelevantColumns();
+        String sql = buildCodeSideRowHashQuery(segment, schema, keyColumns, relevantColumns);
+        int keyColumnCount = keyColumns.size();
+        int normalizedKeyOffset = keyColumnCount;
+        int normalizedRowOffset = keyColumnCount * 2;
+        int normalizedColumnCount = relevantColumns.size();
+        List<CodeSideRowHash> rowHashes = new ArrayList<>();
+
+        Connection connection = null;
+        PreparedStatement statement = null;
+        ResultSet resultSet = null;
+
+        try {
+            connection = getConnection();
+            statement = connection.prepareStatement(sql);
+            statement.setFetchSize(1000);
+            resultSet = statement.executeQuery();
+
+            while (resultSet.next()) {
+                List<Object> primaryKey = new ArrayList<>(keyColumnCount);
+                List<String> normalizedKey = new ArrayList<>(keyColumnCount);
+                for (int i = 0; i < keyColumnCount; i++) {
+                    primaryKey.add(resultSet.getObject(i + 1));
+                    normalizedKey.add(resultSet.getString(normalizedKeyOffset + i + 1));
+                }
+
+                List<String> normalizedRow = new ArrayList<>(normalizedColumnCount);
+                for (int i = 0; i < normalizedColumnCount; i++) {
+                    normalizedRow.add(resultSet.getString(normalizedRowOffset + i + 1));
+                }
+
+                rowHashes.add(new CodeSideRowHash(
+                        primaryKey,
+                        buildDelimitedValues(normalizedKey),
+                        computeRowHash(normalizedRow)));
+            }
+
+            return rowHashes;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error computing SQLite row hashes in code", e);
+        } finally {
+            ResourceManager.closeJdbcResources(statement, resultSet);
+            releaseQuietly(connection);
+        }
+    }
+
+    private String computeSegmentChecksum(List<CodeSideRowHash> rowHashes) {
+        if (rowHashes.isEmpty()) {
+            return "";
+        }
+
+        List<CodeSideRowHash> orderedRowHashes = new ArrayList<>(rowHashes);
+        orderedRowHashes.sort(Comparator.comparing(CodeSideRowHash::normalizedKey));
+
+        StringBuilder concatenatedHashes = new StringBuilder();
+        for (int i = 0; i < orderedRowHashes.size(); i++) {
+            if (i > 0) {
+                concatenatedHashes.append('|');
+            }
+            concatenatedHashes.append(orderedRowHashes.get(i).rowHash());
+        }
+
+        return md5Hex(concatenatedHashes.toString());
+    }
+
+    private String computeRowHash(List<String> row) {
+        return md5Hex(buildDelimitedValues(row));
+    }
+
+    private String buildDelimitedValues(List<String> values) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                builder.append('|');
+            }
+            String value = values.get(i);
+            builder.append(value == null ? "" : value);
+        }
+        return builder.toString();
+    }
+
+    private String buildCodeSideRowHashQuery(
+            TableSegment segment,
+            TableSchema schema,
+            List<String> keyColumns,
+            List<String> relevantColumns) {
+        Map<String, DataType> columnDataTypes = new HashMap<>();
+        for (String column : relevantColumns) {
+            columnDataTypes.put(column, schema.getColumnType(column));
+        }
+
+        List<String> selectColumns = new ArrayList<>();
+        for (String keyColumn : keyColumns) {
+            selectColumns.add(quote(keyColumn));
+        }
+        for (String keyColumn : keyColumns) {
+            DataType keyType = columnDataTypes.get(keyColumn);
+            selectColumns.add(dialect.getDataTypeHandler().normalizeColumn(keyColumn, keyType)
+                    + " AS " + quote("normalized_key_" + keyColumn));
+        }
+        for (String column : relevantColumns) {
+            DataType dataType = columnDataTypes.get(column);
+            selectColumns.add(dialect.getDataTypeHandler().normalizeColumn(column, dataType)
+                    + " AS " + quote("normalized_" + column));
+        }
+
+        String schemaName = segment.getTablePath().getSchema().orElse(null);
+        String tableName = segment.getTablePath().getTableName();
+        String whereClause = segment.buildWhereClause();
+        return dialect.getSqlQueryGenerator().getSelectSQL(schemaName, tableName, selectColumns, whereClause, keyColumns);
+    }
+
+    private TableSchema resolveTableSchema(TableSegment segment) {
+        if (segment.getSchema().isPresent()) {
+            return segment.getSchema().get();
+        }
+        return getTableSchema(segment.getTablePath().getComponents());
+    }
+
+    private String md5Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("MD5 algorithm is not available", e);
+        }
+    }
+
+    private static final class CodeSideRowHash {
+        private final List<Object> primaryKey;
+        private final String normalizedKey;
+        private final String rowHash;
+
+        private CodeSideRowHash(List<Object> primaryKey, String normalizedKey, String rowHash) {
+            this.primaryKey = primaryKey;
+            this.normalizedKey = normalizedKey;
+            this.rowHash = rowHash;
+        }
+
+        private List<Object> primaryKey() {
+            return primaryKey;
+        }
+
+        private String normalizedKey() {
+            return normalizedKey;
+        }
+
+        private String rowHash() {
+            return rowHash;
+        }
     }
 
 }

--- a/consilens-core/src/main/java/com/consilens/core/database/connection/ConnectionPoolFactory.java
+++ b/consilens-core/src/main/java/com/consilens/core/database/connection/ConnectionPoolFactory.java
@@ -2,8 +2,8 @@ package com.consilens.core.database.connection;
 
 import com.consilens.connector.api.ConnectionPoolOptimizer;
 import com.consilens.connector.api.DatabaseDialect;
-import com.consilens.connector.api.model.PoolConfiguration;
 import com.consilens.connector.api.enums.DatabaseType;
+import com.consilens.connector.api.model.PoolConfiguration;
 import com.consilens.core.database.dialect.DialectFactory;
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,48 +24,54 @@ public class ConnectionPoolFactory {
      * Create a connection pool with default configuration.
      */
     public static ConnectionPool createPool(String jdbcUrl, String username, String password) {
-        return createPool(jdbcUrl, username, password, DatabaseType.fromJdbcUrl(jdbcUrl));
+        DatabaseType effectiveType = resolveEffectiveType(jdbcUrl, DatabaseType.UNKNOWN);
+        return createPool(jdbcUrl, username, password, effectiveType, getDefaultConfiguration(effectiveType));
     }
 
     /**
      * Create a connection pool with database type specification.
      */
     public static ConnectionPool createPool(String jdbcUrl, String username, String password, DatabaseType databaseType) {
-        return createPool(jdbcUrl, username, password, databaseType, getDefaultConfiguration(databaseType));
+        DatabaseType effectiveType = resolveEffectiveType(jdbcUrl, databaseType);
+        return createPool(jdbcUrl, username, password, effectiveType, getDefaultConfiguration(effectiveType));
     }
 
     /**
      * Create a connection pool with custom configuration.
      */
     public static ConnectionPool createPool(String jdbcUrl, String username, String password, DatabaseType databaseType, PoolConfiguration configuration) {
+        DatabaseType effectiveType = resolveEffectiveType(jdbcUrl, databaseType);
+        String normalizedUsername = normalizeUsernameForCache(effectiveType, username);
+        String normalizedPassword = effectiveType == DatabaseType.SQLITE ? null : password;
+
         // Use cache if available
-        String cacheKey = generateCacheKey(jdbcUrl, username, databaseType);
+        String cacheKey = generateCacheKey(jdbcUrl, normalizedUsername, effectiveType);
         ConnectionPool cachedPool = POOL_CACHE.get(cacheKey);
         if (cachedPool != null && !cachedPool.isClosed()) {
-            log.debug("Returning cached connection pool for {}", databaseType.getDisplayName());
+            log.debug("Returning cached connection pool for {}", effectiveType.getDisplayName());
             return cachedPool;
         }
 
         // Get default configuration from connector
-        PoolConfiguration defaultConfig = getDefaultConfiguration(databaseType);
-        
+        PoolConfiguration defaultConfig = getDefaultConfiguration(effectiveType);
+
         // Build configuration by merging with defaults
         PoolConfiguration poolConfig = configuration != null ? configuration.copy() : defaultConfig.copy();
         poolConfig.setJdbcUrl(jdbcUrl);
-        poolConfig.setUsername(username);
-        poolConfig.setPassword(password);
-        poolConfig.setDatabaseType(databaseType);
-        
+        poolConfig.setUsername(normalizedUsername);
+        poolConfig.setPassword(normalizedPassword);
+        poolConfig.setDatabaseType(effectiveType);
+
         // Preserve connectionInitSql from default config if not set in custom config
         if (poolConfig.getConnectionInitSql() == null && defaultConfig.getConnectionInitSql() != null) {
             poolConfig.setConnectionInitSql(defaultConfig.getConnectionInitSql());
-            log.info("Applied default connectionInitSql for {}: {}", 
-                     databaseType.getDisplayName(), defaultConfig.getConnectionInitSql());
+            log.info("Applied default connectionInitSql for {}: {}",
+                    effectiveType.getDisplayName(), defaultConfig.getConnectionInitSql());
         } else if (poolConfig.getConnectionInitSql() != null) {
-            log.info("Using custom connectionInitSql for {}: {}", 
-                     databaseType.getDisplayName(), poolConfig.getConnectionInitSql());
+            log.info("Using custom connectionInitSql for {}: {}",
+                    effectiveType.getDisplayName(), poolConfig.getConnectionInitSql());
         } else {
-            log.debug("No connectionInitSql configured for {}", databaseType.getDisplayName());
+            log.debug("No connectionInitSql configured for {}", effectiveType.getDisplayName());
         }
 
         // Create new pool
@@ -74,7 +80,7 @@ public class ConnectionPoolFactory {
         // Cache the pool
         POOL_CACHE.put(cacheKey, pool);
 
-        log.info("Created new connection pool for {} at {}", databaseType.getDisplayName(), jdbcUrl.replaceAll("password=[^&]*", "password=***"));
+        log.info("Created new connection pool for {} at {}", effectiveType.getDisplayName(), sanitizeJdbcUrl(jdbcUrl));
         return pool;
     }
 
@@ -86,13 +92,13 @@ public class ConnectionPoolFactory {
             DatabaseDialect dialect = DialectFactory.getDialect(databaseType);
             ConnectionPoolOptimizer optimizer = dialect.getConnectionPoolOptimizer();
             PoolConfiguration config = optimizer.getDefaultConfiguration();
-            
+
             log.debug("Retrieved default configuration from {} connector", databaseType.getDisplayName());
             return config;
         } catch (Exception e) {
-            log.warn("Failed to get default configuration from connector for {}, using generic defaults: {}", 
+            log.warn("Failed to get default configuration from connector for {}, using generic defaults: {}",
                     databaseType.getDisplayName(), e.getMessage());
-            
+
             // Fallback to generic configuration
             PoolConfiguration config = new PoolConfiguration();
             config.setMaxPoolSize(10);
@@ -142,12 +148,12 @@ public class ConnectionPoolFactory {
      * Close and remove a cached connection pool.
      */
     public static void closePool(String jdbcUrl, String username) {
-        String cacheKey = generateCacheKey(jdbcUrl, username, DatabaseType.fromJdbcUrl(jdbcUrl));
+        DatabaseType effectiveType = resolveEffectiveType(jdbcUrl, DatabaseType.UNKNOWN);
+        String cacheKey = generateCacheKey(jdbcUrl, normalizeUsernameForCache(effectiveType, username), effectiveType);
         ConnectionPool pool = POOL_CACHE.remove(cacheKey);
         if (pool != null) {
             pool.close();
-            log.info("Closed and removed cached connection pool for {}",
-                    jdbcUrl.replaceAll("password=[^&]*", "password=***"));
+            log.info("Closed and removed cached connection pool for {}", sanitizeJdbcUrl(jdbcUrl));
         }
     }
 
@@ -190,7 +196,8 @@ public class ConnectionPoolFactory {
      * Get connection pool from cache.
      */
     public static ConnectionPool getCachedPool(String jdbcUrl, String username) {
-        String cacheKey = generateCacheKey(jdbcUrl, username, DatabaseType.fromJdbcUrl(jdbcUrl));
+        DatabaseType effectiveType = resolveEffectiveType(jdbcUrl, DatabaseType.UNKNOWN);
+        String cacheKey = generateCacheKey(jdbcUrl, normalizeUsernameForCache(effectiveType, username), effectiveType);
         return POOL_CACHE.get(cacheKey);
     }
 
@@ -220,6 +227,29 @@ public class ConnectionPoolFactory {
 
     private static String generateCacheKey(String jdbcUrl, String username, DatabaseType databaseType) {
         return String.format("%s:%s@%s", username, databaseType.name(), jdbcUrl);
+    }
+
+    private static DatabaseType resolveEffectiveType(String jdbcUrl, DatabaseType databaseType) {
+        DatabaseType requestedType = databaseType == null ? DatabaseType.UNKNOWN : databaseType;
+        return requestedType == DatabaseType.UNKNOWN ? DatabaseType.fromJdbcUrl(jdbcUrl) : requestedType;
+    }
+
+    private static String normalizeUsernameForCache(DatabaseType databaseType, String username) {
+        if (databaseType == DatabaseType.SQLITE) {
+            return null;
+        }
+        if (username == null || username.trim().isEmpty()) {
+            return username;
+        }
+        return username;
+    }
+
+    private static String sanitizeJdbcUrl(String jdbcUrl) {
+        if (jdbcUrl == null) {
+            return null;
+        }
+        return jdbcUrl.replaceAll("(?i)(password|pwd|passphrase|token|access_token|authToken)=([^&;]+)", "$1=***")
+                .replaceAll("//([^/@:]+):([^@/]+)@", "//$1:***@");
     }
 
     /**

--- a/consilens-core/src/main/java/com/consilens/core/database/connection/HikariConnectionPool.java
+++ b/consilens-core/src/main/java/com/consilens/core/database/connection/HikariConnectionPool.java
@@ -56,6 +56,16 @@ public class HikariConnectionPool implements ConnectionPool {
 
         try {
             Connection connection = dataSource.getConnection();
+            try {
+                initializeConnection(connection);
+            } catch (SQLException e) {
+                try {
+                    connection.close();
+                } catch (SQLException closeException) {
+                    e.addSuppressed(closeException);
+                }
+                throw e;
+            }
 
             waitTime = System.currentTimeMillis() - startTime;
             updateWaitTimeStatistics(waitTime);
@@ -244,18 +254,28 @@ public class HikariConnectionPool implements ConnectionPool {
             DatabaseDialect dialect = DialectFactory.getDialect(config.getDatabaseType());
             ConnectionPoolOptimizer optimizer = dialect.getConnectionPoolOptimizer();
             Properties optimizations = optimizer.getOptimizationProperties(config.isUseSSL());
-            
+
             // Apply all optimization properties to HikariConfig
-            optimizations.forEach((key, value) -> 
+            optimizations.forEach((key, value) ->
                 hikariConfig.addDataSourceProperty(key.toString(), value)
             );
-            
-            log.debug("Applied {} connection pool optimization properties for database type: {}", 
+
+            log.debug("Applied {} connection pool optimization properties for database type: {}",
                     optimizations.size(), config.getDatabaseType().getDisplayName());
         } catch (Exception e) {
-            log.warn("Failed to apply database-specific optimizations for {}, using defaults: {}", 
+            log.warn("Failed to apply database-specific optimizations for {}, using defaults: {}",
                     config.getDatabaseType().getDisplayName(), e.getMessage());
         }
+    }
+
+    private void initializeConnection(Connection connection) throws SQLException {
+        if (connection == null) {
+            return;
+        }
+
+        DatabaseDialect dialect = DialectFactory.getDialect(configuration.getDatabaseType());
+        ConnectionPoolOptimizer optimizer = dialect.getConnectionPoolOptimizer();
+        optimizer.initializeConnection(connection);
     }
 
     private void updateWaitTimeStatistics(long waitTime) {

--- a/consilens-core/src/test/java/com/consilens/core/database/adpter/AbstractDatabaseAdapterSQLiteHashingTest.java
+++ b/consilens-core/src/test/java/com/consilens/core/database/adpter/AbstractDatabaseAdapterSQLiteHashingTest.java
@@ -1,0 +1,148 @@
+package com.consilens.core.database.adpter;
+
+import com.consilens.common.enums.ChecksumAlgorithm;
+import com.consilens.connector.api.DatabaseDialect;
+import com.consilens.connector.api.enums.DatabaseType;
+import com.consilens.connector.api.model.PoolConfiguration;
+import com.consilens.core.database.connection.ConnectionPool;
+import com.consilens.core.database.connection.ConnectionPoolFactory;
+import com.consilens.core.database.dialect.DialectFactory;
+import com.consilens.core.segment.TableSegment;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.MessageDigest;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AbstractDatabaseAdapterSQLiteHashingTest {
+
+    @AfterEach
+    void tearDown() {
+        ConnectionPoolFactory.closeAllPools();
+    }
+
+    @Test
+    void shouldComputeSqliteChecksumInCodeFromNormalizedRows() throws Exception {
+        DefaultDatabaseAdapter adapter = createSqliteAdapter();
+        try {
+            createSampleTable(adapter);
+
+            TableSegment segment = TableSegment.builder()
+                    .database(adapter)
+                    .tablePath(com.consilens.connector.api.model.TablePath.of("sample"))
+                    .keyColumns(Arrays.asList("id"))
+                    .extraColumns(Arrays.asList("name", "amount", "created_at"))
+                    .minKey(Optional.of(Arrays.asList("1")))
+                    .maxKey(Optional.of(Arrays.asList("3")))
+                    .build();
+
+            TableSegment.ChecksumResult result = adapter.countAndChecksum(segment);
+
+            assertEquals(2, result.getCount());
+            assertEquals(md5(md5("1|Alice|10.5000|2026-04-14 08:09:10") + "|" + md5("2|Bob|11.0000|2026-04-14 08:09:11")), result.getChecksum());
+            assertEquals(Arrays.asList("1"), result.getMinKey());
+            assertEquals(Arrays.asList("2"), result.getMaxKey());
+        } finally {
+            adapter.close();
+        }
+    }
+
+    @Test
+    void shouldComputeSqliteRowHashesInCodeFromNormalizedRows() throws Exception {
+        DefaultDatabaseAdapter adapter = createSqliteAdapter();
+        try {
+            createSampleTable(adapter);
+
+            TableSegment segment = TableSegment.builder()
+                    .database(adapter)
+                    .tablePath(com.consilens.connector.api.model.TablePath.of("sample"))
+                    .keyColumns(Arrays.asList("id"))
+                    .extraColumns(Arrays.asList("name", "amount", "created_at"))
+                    .minKey(Optional.of(Arrays.asList("1")))
+                    .maxKey(Optional.of(Arrays.asList("4")))
+                    .build();
+
+            Map<List<Object>, String> hashes = adapter.querySegmentRowHashes(segment);
+
+            assertEquals(3, hashes.size());
+            assertEquals(md5("1|Alice|10.5000|2026-04-14 08:09:10"), hashes.get(Arrays.asList(1)));
+            assertEquals(md5("2|Bob|11.0000|2026-04-14 08:09:11"), hashes.get(Arrays.asList(2)));
+            assertEquals(md5("3||0.0000|"), hashes.get(Arrays.asList(3)));
+        } finally {
+            adapter.close();
+        }
+    }
+
+    @Test
+    void shouldRejectXorChecksumForSqliteCodeSideHashing() throws Exception {
+        DefaultDatabaseAdapter adapter = createSqliteAdapter(ChecksumAlgorithm.XOR);
+        try {
+            createSampleTable(adapter);
+
+            TableSegment segment = TableSegment.builder()
+                    .database(adapter)
+                    .tablePath(com.consilens.connector.api.model.TablePath.of("sample"))
+                    .keyColumns(Arrays.asList("id"))
+                    .extraColumns(Arrays.asList("name", "amount", "created_at"))
+                    .build();
+
+            UnsupportedOperationException exception = assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> adapter.countAndChecksum(segment));
+            assertEquals("SQLite code-side checksum only supports CONCAT algorithm", exception.getMessage());
+        } finally {
+            adapter.close();
+        }
+    }
+
+    private DefaultDatabaseAdapter createSqliteAdapter() {
+        return createSqliteAdapter(ChecksumAlgorithm.CONCAT);
+    }
+
+    private DefaultDatabaseAdapter createSqliteAdapter(ChecksumAlgorithm checksumAlgorithm) {
+        PoolConfiguration poolConfig = new PoolConfiguration();
+        poolConfig.setJdbcUrl("jdbc:sqlite::memory:");
+        poolConfig.setDatabaseType(DatabaseType.SQLITE);
+        poolConfig.setMaxPoolSize(1);
+        poolConfig.setMinIdle(1);
+        poolConfig.setConnectionTimeout(10000);
+        poolConfig.setValidationQuery("SELECT 1");
+
+        ConnectionPool pool = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:", null, null, DatabaseType.SQLITE, poolConfig);
+        DatabaseDialect dialect = DialectFactory.getDialect(DatabaseType.SQLITE);
+        return new DefaultDatabaseAdapter("sqlite-test", pool, dialect, "jdbc:sqlite::memory:", checksumAlgorithm);
+    }
+
+    private void createSampleTable(DefaultDatabaseAdapter adapter) throws Exception {
+        try (Connection connection = adapter.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE sample (id INTEGER PRIMARY KEY, name TEXT, amount NUMERIC, created_at TEXT)");
+            statement.execute("INSERT INTO sample(id, name, amount, created_at) VALUES (1, ' Alice ', 10.5, '2026-04-14 08:09:10')");
+            statement.execute("INSERT INTO sample(id, name, amount, created_at) VALUES (2, 'Bob', 11, '2026-04-14 08:09:11')");
+            statement.execute("INSERT INTO sample(id, name, amount, created_at) VALUES (3, NULL, NULL, NULL)");
+        }
+    }
+
+    private String md5(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+            byte[] hash = digest.digest(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/consilens-core/src/test/java/com/consilens/core/database/connection/ConnectionPoolFactorySQLiteTest.java
+++ b/consilens-core/src/test/java/com/consilens/core/database/connection/ConnectionPoolFactorySQLiteTest.java
@@ -1,0 +1,114 @@
+package com.consilens.core.database.connection;
+
+import com.consilens.connector.api.enums.DatabaseType;
+import com.consilens.connector.api.model.PoolConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConnectionPoolFactorySQLiteTest {
+
+    @AfterEach
+    void tearDown() {
+        ConnectionPoolFactory.closeAllPools();
+    }
+
+    @Test
+    void shouldAllowSqlitePoolConfigurationWithoutUsername() {
+        PoolConfiguration config = new PoolConfiguration();
+        config.setJdbcUrl("jdbc:sqlite::memory:");
+        config.setDatabaseType(DatabaseType.SQLITE);
+
+        assertDoesNotThrow(config::validate);
+    }
+
+    @Test
+    void shouldStillRequireUsernameForNonSqlitePoolConfiguration() {
+        PoolConfiguration config = new PoolConfiguration();
+        config.setJdbcUrl("jdbc:mysql://localhost:3306/test");
+        config.setDatabaseType(DatabaseType.MYSQL);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, config::validate);
+        assertEquals("Username cannot be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void shouldAutoDetectSqliteWhenDatabaseTypeIsUnknown() {
+        PoolConfiguration config = new PoolConfiguration();
+        config.setJdbcUrl("jdbc:sqlite::memory:");
+        config.setDatabaseType(DatabaseType.UNKNOWN);
+
+        assertDoesNotThrow(config::validate);
+        assertEquals(DatabaseType.SQLITE, config.getDatabaseType());
+    }
+
+    @Test
+    void shouldNotPushBlankCredentialsIntoSqlitePoolConfiguration() {
+        ConnectionPool pool = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:",
+                "",
+                "",
+                DatabaseType.SQLITE,
+                null);
+
+        try {
+            PoolConfiguration configuration = pool.getConfiguration();
+            assertNull(configuration.getUsername());
+            assertNull(configuration.getPassword());
+            assertEquals(DatabaseType.SQLITE, configuration.getDatabaseType());
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void shouldUseSqliteDefaultsWhenTypeIsUnknown() {
+        ConnectionPool pool = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:",
+                null,
+                null,
+                DatabaseType.UNKNOWN,
+                null);
+
+        try {
+            PoolConfiguration configuration = pool.getConfiguration();
+            assertEquals(DatabaseType.SQLITE, configuration.getDatabaseType());
+            assertNull(configuration.getUsername());
+            assertNull(configuration.getPassword());
+            assertEquals(1, configuration.getMaxPoolSize());
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void shouldNormalizeSqliteCacheKeyForBlankUsernames() {
+        ConnectionPool poolWithNull = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:",
+                null,
+                null,
+                DatabaseType.UNKNOWN,
+                null);
+
+        ConnectionPool poolWithBlank = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:",
+                "   ",
+                null,
+                DatabaseType.UNKNOWN,
+                null);
+
+        try {
+            assertSame(poolWithNull, poolWithBlank);
+            assertSame(poolWithNull, ConnectionPoolFactory.getCachedPool("jdbc:sqlite::memory:", null));
+            assertSame(poolWithNull, ConnectionPoolFactory.getCachedPool("jdbc:sqlite::memory:", "   "));
+            assertEquals(1, ConnectionPoolFactory.getCachedPoolCount());
+        } finally {
+            poolWithNull.close();
+        }
+    }
+}

--- a/consilens-core/src/test/java/com/consilens/core/database/connection/ConnectionPoolFactorySQLiteTest.java
+++ b/consilens-core/src/test/java/com/consilens/core/database/connection/ConnectionPoolFactorySQLiteTest.java
@@ -5,11 +5,16 @@ import com.consilens.connector.api.model.PoolConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ConnectionPoolFactorySQLiteTest {
 
@@ -109,6 +114,41 @@ class ConnectionPoolFactorySQLiteTest {
             assertEquals(1, ConnectionPoolFactory.getCachedPoolCount());
         } finally {
             poolWithNull.close();
+        }
+    }
+
+    @Test
+    void shouldProvideReusableSqliteConnectionsWithoutRegisteringMd5Function() throws Exception {
+        ConnectionPool pool = ConnectionPoolFactory.createPool(
+                "jdbc:sqlite::memory:",
+                null,
+                null,
+                DatabaseType.SQLITE,
+                null);
+
+        try {
+            try (Connection firstConnection = pool.getConnection();
+                 Statement statement = firstConnection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+                assertEquals(1, resultSet.getInt(1));
+            }
+
+            try (Connection secondConnection = pool.getConnection();
+                 Statement statement = secondConnection.createStatement();
+                 ResultSet resultSet = statement.executeQuery("SELECT 1")) {
+                assertEquals(1, resultSet.getInt(1));
+            }
+
+            try (Connection connection = pool.getConnection();
+                 Statement statement = connection.createStatement()) {
+                assertThrows(Exception.class, () -> {
+                    try (ResultSet ignored = statement.executeQuery("SELECT md5('abc')")) {
+                        fail("Expected SQLite md5 function to be unavailable");
+                    }
+                });
+            }
+        } finally {
+            pool.close();
         }
     }
 }

--- a/consilens-dist/src/main/assembly/assembly.xml
+++ b/consilens-dist/src/main/assembly/assembly.xml
@@ -75,6 +75,7 @@
                 <exclude>com.clickhouse:*</exclude>
                 <exclude>io.trino:trino-jdbc</exclude>
                 <exclude>com.facebook.presto:presto-jdbc</exclude>
+                <exclude>org.xerial:sqlite-jdbc</exclude>
             </excludes>
         </dependencySet>
 
@@ -107,6 +108,7 @@
                 <exclude>org.yaml:snakeyaml</exclude>
                 <exclude>info.picocli:picocli</exclude>
                 <exclude>com.h2database:h2</exclude>
+                <exclude>org.xerial:sqlite-jdbc</exclude>
                 <exclude>io.micrometer:*</exclude>
                 <exclude>org.hdrhistogram:HdrHistogram</exclude>
                 <exclude>org.latencyutils:LatencyUtils</exclude>
@@ -144,6 +146,7 @@
                 <include>com.clickhouse:*</include>
                 <include>io.trino:trino-jdbc</include>
                 <include>com.facebook.presto:presto-jdbc</include>
+                <include>org.xerial:sqlite-jdbc</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/docs/02-配置详解.md
+++ b/docs/02-配置详解.md
@@ -90,12 +90,12 @@ normalization:
 | 字段 | 必填 | 说明 |
 | --- | --- | --- |
 | `source.url` | 是 | 源库 JDBC URL |
-| `source.username` | 是 | 源库用户名 |
-| `source.password` | 否 | 源库密码 |
+| `source.username` | 条件必填 | 除 SQLite 外均需提供；SQLite 可省略 |
+| `source.password` | 否 | 源库密码；SQLite 可省略 |
 | `source.type` | 否 | 显式数据库类型，未填时从 URL 推断 |
 | `target.url` | 是 | 目标库 JDBC URL |
-| `target.username` | 是 | 目标库用户名 |
-| `target.password` | 否 | 目标库密码 |
+| `target.username` | 条件必填 | 除 SQLite 外均需提供；SQLite 可省略 |
+| `target.password` | 否 | 目标库密码；SQLite 可省略 |
 | `target.type` | 否 | 显式数据库类型 |
 
 ### 表与列
@@ -116,6 +116,11 @@ normalization:
 - 两侧主键列数量必须一致。
 - `comparison.compareColumns.source` 和 `comparison.compareColumns.target` 若为空，当前代码不会自动补齐全表列，建议明确配置。
 - 过滤条件会直接拼接到分段查询里，应保证两侧语义等价。
+- SQLite 连接支持显式 `type: sqlite`，也支持直接通过 `jdbc:sqlite:` URL 自动识别。
+- SQLite 连接不要求 `username` 和 `password`。
+- 支持的 SQLite URL 形式包括 `jdbc:sqlite::memory:`、`jdbc:sqlite:/absolute/path/app.db`、`jdbc:sqlite:relative/path/app.db`。
+- `jdbc:sqlite:` 后必须带数据源路径或 `:memory:`，空数据源会在配置校验阶段被拒绝。
+- 若显式写了 `type`，它必须与 JDBC URL 保持一致；例如 SQLite URL 不能搭配 `mysql`。
 
 ## 二、策略与算法
 

--- a/docs/03-插件与数据库支持.md
+++ b/docs/03-插件与数据库支持.md
@@ -21,12 +21,13 @@ Consilens 的数据库适配通过 JDK 原生 `ServiceLoader` 实现，核心扩
 | StarRocks | `consilens-connector-starrocks` |
 | ClickHouse | `consilens-connector-clickhouse` |
 | TiDB | `consilens-connector-tidb` |
+| SQLite | `consilens-connector-sqlite` |
 
 说明：
 
 - [DatabaseType.java](../consilens-connector/consilens-connector-api/src/main/java/com/consilens/connector/api/enums/DatabaseType.java) 中定义了更多枚举值
 - 但“能否真正使用”取决于是否存在对应插件模块和 SPI 注册
-- 当前已完成端到端验证的数据库是 MySQL、PostgreSQL 和 StarRocks；其余内置插件建议在真实场景接入前先自行验证
+- 当前已完成端到端验证的数据库是 MySQL、PostgreSQL 和 StarRocks；SQLite 当前已补齐配置校验、连接测试与方言加载链路，但未承诺完整 checksum / row-hash 比对能力；其余内置插件建议在真实场景接入前先自行验证
 
 ## 二、插件加载机制
 
@@ -92,6 +93,7 @@ com.consilens.connector.mysql.MySQLDatabaseDialectProvider
 这意味着：
 
 - 新增数据库插件后，只要模块被纳入构建并打包，就能通过 `plugins/` 加载
+- JDBC 驱动也会跟随插件一起进入 `plugins/`；例如 SQLite 使用 `org.xerial:sqlite-jdbc`
 - 自定义部署时也可以通过补充 jar 的方式扩展
 
 ## 六、推荐的数据库类型配置
@@ -119,8 +121,30 @@ target:
 - `starrocks`
 - `clickhouse`
 - `tidb`
+- `sqlite`
 
-## 七、不同策略对数据库插件的要求
+## 七、SQLite 使用说明
+
+建议配置：
+
+```yaml
+source:
+  type: sqlite
+  url: jdbc:sqlite:/tmp/source.db
+
+target:
+  url: jdbc:sqlite::memory:
+```
+
+说明：
+
+- SQLite 可显式写 `type: sqlite`，也可只写 SQLite JDBC URL 让系统自动识别
+- SQLite 不要求 `username` 和 `password`
+- 支持 `jdbc:sqlite::memory:`、绝对路径和相对路径文件 URL
+- 当前 SQLite 插件主要覆盖配置校验、方言发现、健康检查与元数据查询链路
+- 若进入真正的 checksum / row-hash 比对阶段，仍需要对应 SQL 生成功能支持
+
+## 八、不同策略对数据库插件的要求
 
 ### `checksum`
 


### PR DESCRIPTION
## Summary
- add SQLite dialect/provider wiring plus connector packaging so SQLite can participate in compare flows
- keep SQLite hashing in Java code instead of SQL MD5, and add adapter/connection-pool support with focused regression coverage
- align SQLite temporal normalization with MySQL/PostgreSQL semantics, including timezone-bearing values, julian day/epoch inputs, and malformed suffix handling

## Test plan
- [x] `mvn -f /Users/caoty/IdeaProjects/consilens/.claude/worktrees/agent-a73d9369/pom.xml -pl consilens-connector/consilens-connector-plugins/consilens-connector-sqlite -am -Dtest=SQLiteDatabaseDialectTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `./mvnw -f /Users/caoty/IdeaProjects/consilens/.claude/worktrees/agent-a73d9369/pom.xml -q -pl consilens-connector/consilens-connector-plugins/consilens-connector-sqlite -am verify`
- [x] `mvn -f /Users/caoty/IdeaProjects/consilens/.claude/worktrees/agent-a73d9369/pom.xml -pl consilens-dist -am -Prelease -DskipTests package`
- [ ] run end-to-end compare flow against a fresh packaged CLI artifact

## Notes
- SQLite still does not support SQL-side XOR/MD5 hashing; those paths fail explicitly and hashing remains code-side.
- There is a non-blocking follow-up opportunity to add a dedicated wide-query guard for `SQLITE_TOOBIG` risk.
